### PR TITLE
Support very large template folders

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const mkdirp = require('mkdirp')
 const noop = require('noop2')
 const path = require('path')
 const pump = require('pump')
-const fs = require('fs')
+const fs = require('graceful-fs')
 
 module.exports = copyTemplateDir
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "end-of-stream": "^1.1.0",
+    "graceful-fs": "^4.1.3",
     "maxstache-stream": "^1.0.0",
     "mkdirp": "^0.5.1",
     "noop2": "^2.0.0",


### PR DESCRIPTION
For a very large template folder I got 'Error: EMFILE, too many open files'.

Switching to graceful-fs (a direct drop in) fixes the issue.
