### PR TITLE
Ignore conflicting template files when transforming

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ const fs = require('graceful-fs')
 
 module.exports = copyTemplateDir
 
+copyTemplateDir.blacklist = ['hbs', 'mustache', 'njk', 'twig']
+
 // High throughput template dir writes
 // (str, str, obj, fn) -> null
 function copyTemplateDir (srcDir, outDir, vars, cb) {
@@ -67,9 +69,18 @@ function writeFile (outDir, vars, file) {
       const ts = maxstacheStream(vars)
       const ws = fs.createWriteStream(outFile)
 
-      pump(rs, ts, ws, done)
+      if (isBlacklisted(file)) {
+        pump(rs, ws, done)
+      } else {
+        pump(rs, ts, ws, done)
+      }
     })
   }
+}
+
+function isBlacklisted (file) {
+  const ext = file.path.split('.').pop()
+  return copyTemplateDir.blacklist.indexOf(ext) !== -1
 }
 
 // remove a leading underscore

--- a/test/fixtures/templates/template.twig
+++ b/test/fixtures/templates/template.twig
@@ -1,0 +1,1 @@
+This should tag should remain {{ hello }}

--- a/test/fixtures/templates/{{foo}}.hbs
+++ b/test/fixtures/templates/{{foo}}.hbs
@@ -1,0 +1,1 @@
+This should tag should remain {{ hello }}


### PR DESCRIPTION
Happy to leave this in my fork if its out of scope of the repository. We have a use case where we need to copy templates (handlebars, twig, nunjucks) as part of a template directory, but still have the filename templating. 

I didn't want to change the API, so I added the blacklist as a static property that could, in theory, be changed by a consumer to extend the blacklist.