### PR TITLE
⚡️ Dotfiles that arent prefixed with _ are not passed to maxstache.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function copyTemplateDir (srcDir, outDir, vars, cb) {
     rs.on('data', function (file) {
       const dotfile = new RegExp(/^[.].*$/).test(file.name)
       if (dotfile) {
-        createdFiles.push(path.join(outDir, file.path, vars))
+        createdFiles.push(path.join(outDir, file.path))
         streams.push(writeDotfile(outDir, vars, file))
       } else {
         createdFiles.push(path.join(outDir, maxstache(removeUnderscore(file.path), vars)))
@@ -86,7 +86,7 @@ function writeDotfile (outDir, vars, file) {
     const fileName = file.path
     const inFile = file.fullPath
     const parentDir = file.parentDir
-    const outFile = path.join(outDir, fileName, vars)
+    const outFile = path.join(outDir, fileName)
 
     mkdirp(path.join(outDir, parentDir), function (err) {
       if (err) return done(err)

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function copyTemplateDir (srcDir, outDir, vars, cb) {
 
     // create a new stream for every file emitted
     rs.on('data', function (file) {
-      const dotfile = new RegExp(/^[.].*$/).test(file)
+      const dotfile = new RegExp(/^[.].*$/).test(file.name)
       if (dotfile) {
         createdFiles.push(path.join(outDir, file.path, vars))
         streams.push(writeDotfile(outDir, vars, file))


### PR DESCRIPTION
Hello!

Not sure if you want this, but I needed it so I figured I'd share it back.  This PR makes it so that if you dont put an `_` in front of a dotfile, it isn't passed to the maxstache engine.  I found that if your template contained images or other non text files maxstache would corrupt them.  Now I just add a `.` to the beginning (`.image.png`) and rename the file after transformation. 

Currently I have a tool that uses `copy-tempate-dir` to template to a temporary directory which I then process further. It would be nice if I could get the whole job done with `copy-template-dir`.  We would need to add a post process action or something similar.  

Anyway, I hope this makes it in so I dont have to keep my own fork.  Have a good one.