### PR TITLE
Update readdirp to address deprecation, inline noop2, and update minor versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function copyTemplateDir (srcDir, outDir, vars, cb) {
   mkdirp(outDir, function (err) {
     if (err) return cb(err)
 
-    const rs = readdirp({ root: srcDir })
+    const rs = readdirp(srcDir)
     const streams = []
     const createdFiles = []
 
@@ -56,7 +56,7 @@ function writeFile (outDir, vars, file) {
   return function (done) {
     const fileName = file.path
     const inFile = file.fullPath
-    const parentDir = file.parentDir
+    const parentDir = path.dirname(file.path)
     const outFile = path.join(outDir, maxstache(removeUnderscore(fileName), vars))
 
     mkdirp(path.join(outDir, maxstache(parentDir, vars)), function (err) {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ const eos = require('end-of-stream')
 const readdirp = require('readdirp')
 const assert = require('assert')
 const mkdirp = require('mkdirp')
-const noop = require('noop2')
 const path = require('path')
 const pump = require('pump')
 const fs = require('graceful-fs')
@@ -16,7 +15,7 @@ module.exports = copyTemplateDir
 // (str, str, obj, fn) -> null
 function copyTemplateDir (srcDir, outDir, vars, cb) {
   if (!cb) {
-    if (!vars) vars = noop
+    if (!vars) vars = function () {}
     cb = vars
     vars = {}
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "maxstache": "^1.0.7",
     "maxstache-stream": "^1.0.4",
     "mkdirp": "^0.5.6",
-    "noop2": "^2.0.0",
     "pump": "^1.0.3",
     "readdirp": "^2.0.0",
     "run-parallel": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "maxstache-stream": "^1.0.4",
     "mkdirp": "^0.5.6",
     "pump": "^1.0.3",
-    "readdirp": "^2.0.0",
+    "readdirp": "^3.6.0",
     "run-parallel": "^1.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,15 +18,15 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "end-of-stream": "^1.1.0",
-    "graceful-fs": "^4.1.3",
-    "maxstache": "^1.0.0",
-    "maxstache-stream": "^1.0.0",
-    "mkdirp": "^0.5.1",
+    "end-of-stream": "^1.4.4",
+    "graceful-fs": "^4.2.11",
+    "maxstache": "^1.0.7",
+    "maxstache-stream": "^1.0.4",
+    "mkdirp": "^0.5.6",
     "noop2": "^2.0.0",
-    "pump": "^1.0.0",
+    "pump": "^1.0.3",
     "readdirp": "^2.0.0",
-    "run-parallel": "^1.1.4"
+    "run-parallel": "^1.2.0"
   },
   "devDependencies": {
     "concat-stream": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "run-parallel": "^1.1.4"
   },
   "devDependencies": {
-    "concat-stream": "^1.5.0",
-    "dependency-check": "^2.5.1",
-    "istanbul": "^0.3.21",
-    "rimraf": "^2.4.3",
-    "standard": "^5.3.1",
-    "tape": "^4.2.0"
+    "concat-stream": "^1.6.2",
+    "dependency-check": "^2.10.1",
+    "istanbul": "^0.3.22",
+    "rimraf": "^2.7.1",
+    "standard": "^17.1.0",
+    "tape": "^4.16.2"
   },
   "files": [
     "index.js",

--- a/test/index.js
+++ b/test/index.js
@@ -40,7 +40,7 @@ test('should write a bunch of files', function (t) {
       return path.relative(outDir, filePath)
     }), 'reported as created')
 
-    readdirp({ root: outDir }).pipe(concat({ object: true }, function (arr) {
+    readdirp(outDir).pipe(concat({ object: true }, function (arr) {
       t.ok(Array.isArray(arr), 'is array')
 
       const names = arr.map(function (file) { return file.path })
@@ -61,7 +61,7 @@ test('should inject context variables strings', function (t) {
   copy(inDir, outDir, { foo: 'bar' }, function (err) {
     t.error(err)
 
-    readdirp({ root: outDir }).pipe(concat({ object: true }, function (arr) {
+    readdirp(outDir).pipe(concat({ object: true }, function (arr) {
       t.ok(Array.isArray(arr), 'is array')
 
       const file = path.join(outDir, '1.txt')
@@ -87,7 +87,7 @@ test('should inject context variables strings into filenames', function (t) {
   copy(inDir, outDir, { foo: 'bar' }, function (err) {
     t.error(err)
 
-    readdirp({ root: outDir }).pipe(concat({ object: true }, function (arr) {
+    readdirp(outDir).pipe(concat({ object: true }, function (arr) {
       t.ok(Array.isArray(arr), 'is array')
 
       const file = path.join(outDir, 'bar.txt')
@@ -110,7 +110,7 @@ test('should inject context variables strings into directory names', function (t
   copy(inDir, outDir, { foo: 'bar' }, function (err) {
     t.error(err)
 
-    readdirp({ root: outDir }).pipe(concat({ object: true }, function (arr) {
+    readdirp(outDir).pipe(concat({ object: true }, function (arr) {
       t.ok(Array.isArray(arr), 'is array')
 
       const dir = path.join(outDir, 'bar')


### PR DESCRIPTION
1. Currently, copy-template-dir depends on readdirp@2.2.1, which depends on micromatch@3.1.10 → snapdragon → [source-map-resolve](https://github.com/lydell/source-map-resolve) (deprecated). This is unnecessary; this PR fixes it by updating readdirp to 3.6.0.

   This might be considered a breaking change though, as readdirp 3.x raised the minimum Node version to 8.x.

2. This PR also inlines noop2 (`function () {}`) - this arguably saves 420.5 MiB of unnecessary bandwidth per week (3289 bytes * 134076 weekly downloads of `copy-template-dir` as of 2023-06-02).

3. Additionally, I also updated the declared minor versions of other dependencies, as well as updating Standard to latest. This did not introduce any formatting changes.