### PR TITLE
Switch to GitHub Actions as Travis is no longer available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version:
+          # - 0.12
+          # - 4.x
+          # - 6.x
+          - 8.x # minimum as readdirp 3.x uses object spread
+          - 14.x
+          - 20.x
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install packages
+        run: npm install
+      - name: Test
+        run: npm run test:cov
+      # - name: Upload coverage
+      #   run: |
+      #     npm install -g codecov.io
+      #     cat ./coverage/lcov.info | codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-node_js:
-- "0.12"
-- "4"
-sudo: false
-language: node_js
-script: "npm run test:cov"
-after_script: "npm i -g codecov.io && cat ./coverage/lcov.info | codecov"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # copy-template-dir
 [![NPM version][npm-image]][npm-url]
-[![build status][travis-image]][travis-url]
+[![build status][github-actions-image]][github-actions-url]
 [![Test coverage][codecov-image]][codecov-url]
 [![Downloads][downloads-image]][downloads-url]
 [![js-standard-style][standard-image]][standard-url]
@@ -51,8 +51,8 @@ paths to created files if there were no errors.
 
 [npm-image]: https://img.shields.io/npm/v/copy-template-dir.svg?style=flat-square
 [npm-url]: https://npmjs.org/package/copy-template-dir
-[travis-image]: https://img.shields.io/travis/yoshuawuyts/copy-template-dir/master.svg?style=flat-square
-[travis-url]: https://travis-ci.org/yoshuawuyts/copy-template-dir
+[github-actions-image]: https://img.shields.io/github/actions/workflow/status/yoshuawuyts/copy-template-dir/test.yml?style=flat-square
+[github-actions-url]: https://github.com/yoshuawuyts/copy-template-dir/actions
 [codecov-image]: https://img.shields.io/codecov/c/github/yoshuawuyts/copy-template-dir/master.svg?style=flat-square
 [codecov-url]: https://codecov.io/github/yoshuawuyts/copy-template-dir
 [downloads-image]: http://img.shields.io/npm/dm/copy-template-dir.svg?style=flat-square


### PR DESCRIPTION
Travis CI is no longer freely available for open source projects. This PR switches to GitHub Actions instead, now that it is a thing.

The workflow is mostly copied from <https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs>.

- Uses `npm install` instead of `npm ci` as the latter does not work when there isn't a lock file.
- Test on Node 8.x, 14.x, and 20.x; 8.x will be the minimum [if readdirp is updated to 3.6.0](https://github.com/yoshuawuyts/copy-template-dir/pull/17), while 14.x and 20.x are sort of arbitrarily chosen.
- I copied the coverage uploading command from .travis.yml, but left it commented out. This way, if you decide to set up coverage uploading again, at least the command is right there and you would just have to set up credentials.